### PR TITLE
Upgrade to 1.28.0

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "1.28.0rc0"
+pants_version = "1.28.0rc1"
 v1 =  false  # Turn off the v1 execution engine.
 v2 = true  # Enable the v2 execution engine.
 v2_ui = true  # Enable the v2 execution engine's terminal-based UI.

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "1.28.0rc1"
+pants_version = "1.28.0"
 v1 =  false  # Turn off the v1 execution engine.
 v2 = true  # Enable the v2 execution engine.
 v2_ui = true  # Enable the v2 execution engine's terminal-based UI.
@@ -25,7 +25,7 @@ plugins2 = []
 
 [source]
 # The Python source root is the repo root. See https://pants.readme.io/docs/source-roots.
-root_patterns = ["^"]
+root_patterns = ["/"]
 
 [python-setup]
 # The default interpreter compatibility for code in this repo. Individual targets can ovverride


### PR DESCRIPTION
This requires using the new syntax for source roots at the root level.

We don't upgrade to 1.29.0.dev1 yet because Protobuf is broken.