### PR TITLE
Update `pants` and `pants.toml` for 2.0 release

### DIFF
--- a/pants
+++ b/pants
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Copyright 2020 Pants project contributors.
+# Copyright 2020 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 # =============================== NOTE ===============================

--- a/pants.toml
+++ b/pants.toml
@@ -2,15 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "1.30.0"
-v1 =  false  # Turn off the v1 execution engine.
-v2 = true  # Enable the v2 execution engine.
+pants_version = "2.0.0.dev4"
 pantsd = true  # Enable the Pants daemon for better performance.
 
-backend_packages = []  # Deregister all v1 backends.
-
-# List v2 backends here.
-backend_packages2.add = [
+# List backends here.
+backend_packages = [
   'pants.backend.awslambda.python',
   'pants.backend.codegen.protobuf.python',
   'pants.backend.python',
@@ -20,8 +16,8 @@ backend_packages2.add = [
   'pants.backend.python.lint.isort',
 ]
 
-# List v2 plugins here.
-plugins2 = []
+# List plugins here.
+plugins = []
 
 [source]
 # The Python source root is the repo root. See https://pants.readme.io/docs/source-roots.

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.0.0.dev2"
+pants_version = "2.0.0.dev5"
 pantsd = true  # Enable the Pants daemon for better performance.
 
 # List backends here.

--- a/pants.toml
+++ b/pants.toml
@@ -6,7 +6,7 @@ pants_version = "2.0.0.dev4"
 pantsd = true  # Enable the Pants daemon for better performance.
 
 # List backends here.
-backend_packages = [
+backend_packages.add = [
   'pants.backend.awslambda.python',
   'pants.backend.codegen.protobuf.python',
   'pants.backend.python',

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.0.0.dev4"
+pants_version = "2.0.0.dev2"
 pantsd = true  # Enable the Pants daemon for better performance.
 
 # List backends here.

--- a/pants_from_sources
+++ b/pants_from_sources
@@ -36,10 +36,10 @@ function string_list() {
 }
 
 export PANTS_VERSION="$(cat "${PANTS_SOURCE}/src/python/pants/VERSION")"
-export PANTS_PLUGINS2="$(string_list plugins)"
+export PANTS_PLUGINS="$(string_list plugins)"
 export PANTS_PYTHONPATH="+$(string_list pythonpath)"
-export PANTS_BACKEND_PACKAGES2="+$(string_list backend_packages)"
-export PANTS_ENABLE_PANTSD="${ENABLE_PANTSD}"
+export PANTS_BACKEND_PACKAGES="+$(string_list backend_packages)"
+export PANTS_PANTSD="${ENABLE_PANTSD}"
 export no_proxy="*"
 
 exec "${PANTS_SOURCE}/pants" "--no-verify-config" "$@"


### PR DESCRIPTION
This PR is in preparation for the Pants 2.0.0 release. It's in draft mode because 2.0 is not stable yet, but it could be merged once that changes.

The PR is intended to
(a) serve as a working example for people who want to explore Pants 2.0
(b) show the diff between a working 1.x and 2.0 configuration

Progress:
- ~~Right now, the upgrade to 2.0.0.dev4 still fails: ./pants list :: raises 31 rules errors - any feedback is appreciated~~
- ~~Update: According to @stuhood the failure seems to be related to `protoc` not being ready for 2.0 yet (https://github.com/pantsbuild/pants/issues/10425)~~
- ~~Update 2: Downgrading to 2.0.0.dev2 fixed the issue~~
- Update 3: The new 2.0.0.dev5 fixes the regression, everything seems to work on the latest dev release now