### PR TITLE
Upgrade to 2.0.0.dev7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,5 @@ script:
   - ./pants --changed-since=origin/master --changed-include-dependees=transitive test
   # Smoke test that our release process will work.
   - ./pants binary helloworld/main.py helloworld/main_py2.py
-  - ./pants setup-py --args="bdist_wheel" helloworld/util:util-dist
+  - ./pants setup-py --args="bdist_wheel" helloworld/util:dist
   - ./pants awslambda helloworld:helloworld-awslambda

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ install:
 script:
   - ./pants --changed-since=origin/master lint
   - ./pants --changed-since=origin/master --changed-include-dependees=transitive test
+  # Smoke test that our release process will work.
+  - ./pants binary helloworld/main.py helloworld/main_py2.py
+  - ./pants setup-py --args="bdist_wheel" helloworld/util:util-dist
+  - ./pants awslambda helloworld:helloworld-awslambda

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Try these out in this repo!
 ## Run `setup.py` commands
 
 ```
-./pants setup-py --args="bdist_wheel" helloworld/util:util_dist  # Build a wheel.
+./pants setup-py --args="bdist_wheel" helloworld/util:dist  # Build a wheel.
 ```
 
 ## Build an AWS Lambda

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Try these out in this repo!
 ## Run `setup.py` commands
 
 ```
-./pants setup-py --args="bdist_wheel" helloworld/util  # Build a wheel.
+./pants setup-py --args="bdist_wheel" helloworld/util:util_dist  # Build a wheel.
 ```
 
 ## Build an AWS Lambda

--- a/helloworld/util/BUILD
+++ b/helloworld/util/BUILD
@@ -1,32 +1,37 @@
 # Copyright 2020 Pants project contributors.
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
+# See https://pants.readme.io/docs/python-setup-py-goal.
+python_distribution(
+  name="util-dist",
+  dependencies=[":util"],
+  provides=setup_py(
+      name='helloworld.util',
+      version='0.0.1',
+      description='Greeting library utilities.',
+  ),
+)
+
 python_library(
     # `name` defaults to the name of this directory, i.e., `util`.
     # `sources` defaults to ['*.py', '!*_test.py', '!test_*.py', '!conftest.py'].
-    dependencies = [
+    dependencies=[
         "//:setuptools",
         "//:translate",
         "helloworld/util/proto",
     ],
-    # See https://pants.readme.io/docs/python-setup-py-goal.
-    provides = setup_py(
-        name='helloworld.util',
-        version='0.0.1',
-        description='Greeting library utilities.',
-    ),
 )
 
 python_tests(
-    name = 'tests',
+    name='tests',
     # `sources` defaults to ['*_test.py', 'test_*.py', 'conftest.py'].
-    dependencies = [
+    dependencies=[
         ":config_loader_test_data",
         ":util",
     ],
 )
 
 resources(
-    name = 'config_loader_test_data',
-    sources = ['config_loader_test_data.json'],
+    name='config_loader_test_data',
+    sources=['config_loader_test_data.json'],
 )

--- a/helloworld/util/BUILD
+++ b/helloworld/util/BUILD
@@ -3,7 +3,7 @@
 
 # See https://pants.readme.io/docs/python-setup-py-goal.
 python_distribution(
-  name="util-dist",
+  name="dist",
   dependencies=[":util"],
   provides=setup_py(
       name='helloworld.util',

--- a/pants.ci.toml
+++ b/pants.ci.toml
@@ -1,3 +1,6 @@
+# Copyright 2020 Pants project contributors.
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
 # See https://pants.readme.io/docs/using-pants-in-ci.
 
 [GLOBAL]
@@ -6,7 +9,7 @@ pantsd = false
 # Limit the maximum number of concurrent processes. Change this
 # to a number that makes sense for your CI setup, based on
 # the number of cores/threads.
-process_execution_local_parallelism = 4
+process_execution_local_parallelism = 2
 
 [python-setup]
 # Limit the maximum number of concurrent jobs used to resolve third

--- a/pants.toml
+++ b/pants.toml
@@ -2,10 +2,9 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.0.0.dev5"
+pants_version = "2.0.0.dev7"
 pantsd = true  # Enable the Pants daemon for better performance.
 
-# List backends here.
 backend_packages.add = [
   'pants.backend.awslambda.python',
   'pants.backend.codegen.protobuf.python',
@@ -15,9 +14,6 @@ backend_packages.add = [
   'pants.backend.python.lint.flake8',
   'pants.backend.python.lint.isort',
 ]
-
-# List plugins here.
-plugins = []
 
 [source]
 # The Python source root is the repo root. See https://pants.readme.io/docs/source-roots.
@@ -39,3 +35,6 @@ config = ".flake8"
 
 [isort]
 config = [".isort.cfg"]
+
+[python-infer]
+imports = false


### PR DESCRIPTION
Remaining followups:

* [ ] Fix `./pants run helloworld/main.py` failing due to import error. Test it in CI.
* [ ] Turn on dependency inference. Needs docs update.
* [ ] Enable MyPy.
* [ ] Possibly change Protobuf structure to show off the new `python_source_root` plugin field. Needs docs update.
* [ ] Use `resolve_all_constraints`. Needs docs update.
* [ ] Fix all references to readme.io. Fix the `master` branch too.
* [ ] Update the `./pants` script. Fix the `master` branch too.