### PR TITLE
Make our py3 binary non-zip-safe.

### DIFF
--- a/helloworld/BUILD
+++ b/helloworld/BUILD
@@ -10,6 +10,7 @@ python_binary(
         "//:ansicolors",
         "helloworld/greet",
     ],
+    zip_safe=False
 )
 
 # Note: Has sdist dependencies, so must be built on Linux.

--- a/helloworld/BUILD
+++ b/helloworld/BUILD
@@ -10,6 +10,8 @@ python_binary(
         "//:ansicolors",
         "helloworld/greet",
     ],
+    # In 1.30 the default is True, but pep420 implicit namespaces don't work well with zipped pexes.
+    # In 2.x the default will be False, and we should soon fix the pep420 issues with zipped pexes anyway.
     zip_safe=False
 )
 


### PR DESCRIPTION
Otherwise PEP420 implicit namespaces don't work.