### PR TITLE
Remove plugin/path/backend variables from `pants_from_sources` script.

### DIFF
--- a/pants_from_sources
+++ b/pants_from_sources
@@ -16,29 +16,7 @@ PANTS_SOURCE="${PANTS_SOURCE:-../pants}"
 # you won't want pantsd running.  You can override this by setting ENABLE_PANTSD=true.
 ENABLE_PANTSD="${ENABLE_PANTSD:-false}"
 
-backend_packages=(
-)
-
-pythonpath=(
-)
-
-plugins=(
-)
-
-function string_list() {
-  eval local -r list_variable="\${$1[@]}"
-
-  echo -n "["
-  for item in ${list_variable}; do
-    echo -n "\"${item}\","
-  done
-  echo -n "]"
-}
-
 export PANTS_VERSION="$(cat "${PANTS_SOURCE}/src/python/pants/VERSION")"
-export PANTS_PLUGINS="$(string_list plugins)"
-export PANTS_PYTHONPATH="+$(string_list pythonpath)"
-export PANTS_BACKEND_PACKAGES="+$(string_list backend_packages)"
 export PANTS_PANTSD="${ENABLE_PANTSD}"
 export no_proxy="*"
 


### PR DESCRIPTION
If someone wanted to override any of these, they could do so via environment variables. But I've never seen it be necessary to actually commit an edit, because when testing with a wildly different version of Pants, it's usually a temporary measure.