### PR TITLE
Update the README.md for a better experience for MacOS users

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ example layouts.
 You run Pants goals using the `./pants` wrapper script, which will bootstrap the
 configured version of Pants if necessary.
 
+> :question: Running with Apple Silicon and/or MacOS? You will want to make changes to the `search_path` and
+`interpreter_constraints` values in `pants.toml` before running `./pants` - there is guidance in `pants.toml`
+for those settings.
+
 Use `./pants --version` to see the version of Pants configured for the repo (which you can also find
 in `pants.toml`).
 


### PR DESCRIPTION
It looks me a couple of attempts to successfully follow along from the README.md on a MacBook Pro with Apple Silicon., ultimately coming down to needing to properly configure pants.toml to use pyenv and update the Python interpreter dependency. I believe the statement added to the README.md by this commit will help others in the same situation.