### PR TITLE
Adjust CI cache key names to be consistent

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -45,15 +45,15 @@ jobs:
           ~/.cache/pants/named_caches
         # The Python backend uses named_caches for Pip/PEX state,
         # so it is appropriate to invalidate on requirements.txt changes.
-        key: named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('requirements.txt') }}
+        key: pants-named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('requirements.txt') }}
         # Note that falling back to a restore key may give a useful partial result that will save time
         # over completely clean state, but will cause the cache entry to grow without bound over time.
         # See https://pants.readme.io/docs/using-pants-in-ci for tips on how to periodically clean it up.
         # Alternatively you may want to avoid using restore keys.
         restore-keys: |
-          pants-setup-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('requirements.txt') }}
-          pants-setup-${{ runner.os }}-${{ hashFiles('pants.toml') }}-
-          pants-setup-${{ runner.os }}-
+          pants-named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-${{ hashFiles('requirements.txt') }}
+          pants-named-caches-${{ runner.os }}-${{ hashFiles('pants.toml') }}-
+          pants-named-caches-${{ runner.os }}-
     # If you're not using a fine-grained remote caching service (see https://www.pantsbuild.org/docs/remote-caching),
     # then you may also want to preserve the local Pants cache (lmdb_store). However this must invalidate for
     # changes to any file that can affect the build, so may not be practical in larger repos.
@@ -63,9 +63,9 @@ jobs:
       with:
         path: |
           ~/.cache/pants/lmdb_store
-        key: pants-setup-${{ runner.os }}-${{ hashFiles('**/*') }}
+        key: pants-lmdb-store-${{ runner.os }}-${{ hashFiles('**/*') }}
         # Same caveat as above regarding the issues with restore keys.
-        restore-keys: pants-setup-${{ runner.os }}-
+        restore-keys: pants-lmdb-store-${{ runner.os }}-
     - name: Setup Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
This adjusts the cache keys used in the CI setup based on the improved version from #104. I think there were some typos (e.g. using `pants-setup-...` for the `named_caches` restore key), and it seems that scoping everything under `pants-{name}-...` is nifty.