### PR TITLE
fix path to pants.log

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -65,5 +65,5 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: pants-log
-        path: .pants.d/pants.log
+        path: .pants.d/workdir/pants.log
       if: always()  # We want the log even on failures.


### PR DESCRIPTION
The log file is in workdir, according to https://github.com/pantsbuild/pants/blob/44a06c5825e294757fb1dfe5920ea4b81db56023/src/python/pants/init/logging.py#L232 The path referred to in the docs is preceded by workdir: https://github.com/pantsbuild/pants/blob/44a06c5825e294757fb1dfe5920ea4b81db56023/docs/docs/using-pants/using-pants-in-ci.mdx#L240