### PR TITLE
Update GitHub actions to most recent versions

### DIFF
--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: pantsbuild/actions/init-pants@v5-scie-pants
+    - uses: pantsbuild/actions/init-pants@v8
       # This action bootstraps pants and manages 2-3 GHA caches.
       # See: github.com/pantsbuild/actions/tree/main/init-pants/
       with:

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -24,7 +24,7 @@ jobs:
         python-version: [3.9]
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - uses: pantsbuild/actions/init-pants@v5-scie-pants

--- a/.github/workflows/pants.yaml
+++ b/.github/workflows/pants.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         python-version: [3.9]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
The template project currently uses outdated versions of _action/checkout,_ _action/setup-python,_ and _init-pants._ The checkout and setup-python actions cause deprecation warnings in the GitHub workflow.

This PR updates the three mentioned actions to their respective latest versions, which also gets rid of the deprecation warnings.