### PR TITLE
upgrade to Pants v2.23.0rc1 + other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,13 @@ pants test helloworld/translator/translator_test.py -- -k test_unknown_phrase  #
 
 ## Create a PEX binary
 
+The `package` goal requires specifying a target which can be packaged. In this case, the there is a `pex_binary` target with the name `pex_binary` in the `helloworld/BUILD` file.
+
 ```
-pants package helloworld/main.py
+pants package helloworld:pex_binary
 ```
+
+The pex file is output to `dist/helloworld/pex_binary.pex` and can be executed directly.
 
 ## Run a binary directly
 

--- a/get-pants.sh
+++ b/get-pants.sh
@@ -163,7 +163,7 @@ Once installed, if you want to update your "pants" launcher binary, use
 -h | --help: Print this help message.
 
 -d | --bin-dir:
-  The directory to install the scie-pants binary in, "~/bin" by default.
+  The directory to install the scie-pants binary in, "~/.local/bin" by default.
 
 -b | --base-name:
   The name to use for the scie-pants binary, "pants" by default.
@@ -176,7 +176,7 @@ Once installed, if you want to update your "pants" launcher binary, use
 EOF
 }
 
-bin_dir="${HOME}/bin"
+bin_dir="${HOME}/.local/bin"
 base_name="pants"
 version="latest/download"
 while (($# > 0)); do

--- a/pants.toml
+++ b/pants.toml
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 [GLOBAL]
-pants_version = "2.21.0"
+pants_version = "2.23.0rc1"
 backend_packages.add = [
   "pants.backend.build_files.fmt.black",  
   "pants.backend.python",
@@ -25,7 +25,7 @@ root_patterns = ["/"]
 # The default interpreter constraints for code in this repo. Individual targets can override
 #  this with the `interpreter_constraints` field. See
 #  https://www.pantsbuild.org/docs/python-interpreter-compatibility.
-
+#
 # Modify this if you don't have Python 3.9 on your machine.
 # This can be a range, such as [">=3.8,<3.11"], but it's usually recommended to restrict
 # to a single minor version.
@@ -44,7 +44,3 @@ resolves = { python-default = "python-default.lock"}
 #  problematic system Pythons. See
 #  https://www.pantsbuild.org/docs/python-interpreter-compatibility#changing-the-interpreter-search-path.
 search_path = ["<PATH>", "<PYENV>"]
-
-[python-infer]
-# 2.17 is transitioning to a new, faster parser for dependency inference:
-use_rust_parser = true


### PR DESCRIPTION
Upgrade to Pants v2.23.0rc1, remove an obsolete config, and update the `get-pants.sh` script.